### PR TITLE
Add comments-run Github Action to the repo to set up a workaround so …

### DIFF
--- a/.github/workflows/comment-run.yml
+++ b/.github/workflows/comment-run.yml
@@ -1,0 +1,23 @@
+# Reason this exists: Github doesn't pass repo secrets to untrusted PRs (e.g. PRs from forked repos) since it's untrusted code and we can't guarantee
+#  that the untrusted code won't leak secrets. Kurtosis needs an API secret to run, so this means that PRs from forked repos won't get their Kurtosis
+#  CI checks run. This is a bad experience.
+# To resolve this, we use nwtgck's approach on https://github.community/t/secrets-for-prs-who-are-not-collaborators/17712/11 , where a codeowner will
+#  first review the code, verify it doesn't leak any secrets, and then use Github Actions to create a new PR containing the untrusted PR's code. Because
+#  the PR will be submitted by a codeowner, the secrets will be passed to the CI environment and Kurtosis can run.
+name: "Comment run"
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  comment-run:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # 0 indicates all history
+        fetch-depth: 0
+    - uses: nwtgck/actions-comment-run@v1.1.3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        allowed-associations: '["OWNER"]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Cleaned up `build_and_run.sh` with lessons learned from upgrading the Avalanche test suite to Kurtosis 1.0
 * Explain nil start command for the example impl
 * Added a new bootstrapping process for creating Kurtosis Go testsuites from scratch
+* Add [the comment-run Github Action](https://github.com/nwtgck/actions-comment-run/tree/20297f070391450752be7ac1ebd454fb53f62795#pr-merge-preview) to the repository in order to set up [a workaround for Github not passing secrets to untrusted PRs](https://github.community/t/secrets-for-prs-who-are-not-collaborators/17712), which would prevent auth'd Kurtosis from running
 
 ## 1.0.0
 * Created example test suite to validate that the client library work


### PR DESCRIPTION
…untrusted PRs can still have Kurtosis run against them