### PR TITLE
Revert "Revert "Bump kurtosis-core to 1.1.0""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## TBD
 * Remove log filepath (which is no longer needed now that Kurtosis core reads Docker logs directly)
 * Switch to using [our forked version of action-comment-run](https://github.com/mieubrisse/actions-comment-run) that allows user whitelisting
+* Bump kurtosis-core to 1.1.0
 
 ## 1.1.0
 * Add Apache license

--- a/scripts/build_and_run.sh
+++ b/scripts/build_and_run.sh
@@ -7,7 +7,7 @@ script_dirpath="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
 SUITE_IMAGE="kurtosistech/kurtosis-go-example"
 
 # The name of the release channel of Kurtosis that you'll be using, which indicates which Kurtosis Docker images you'll be using
-KURTOSIS_CORE_CHANNEL="master"
+KURTOSIS_CORE_CHANNEL="1.1.0"
 
 # The directory where Kurtosis will store files it uses in between executions, e.g. access tokens
 KURTOSIS_DIRPATH="${HOME}/.kurtosis"


### PR DESCRIPTION
Undoing the emergency revert, which ended up not being necessary.

Reverts kurtosis-tech/kurtosis-go#43